### PR TITLE
add regex rule: readme.md vars accept white spaces

### DIFF
--- a/homeworks/cloud-testapp/controls/deploy.rb
+++ b/homeworks/cloud-testapp/controls/deploy.rb
@@ -6,13 +6,14 @@ title 'cloud-testapp: deploy'
 control 'Check README.md' do
 
   describe file('README.md') do
-    its('content') { should match /\s*testapp_IP = ((?:[0-9]{1,3}\.){3}[0-9]{1,3})$/m }
-    its('content') { should match /\s*testapp_port = ([0-9]{1,5})$/m }
+    its('content') { should match /\s*testapp_IP\s*=\s*((?:[0-9]{1,3}\.){3}[0-9]{1,3})$/m }
+    its('content') { should match /\s*testapp_port\s*=\s*([0-9]{1,5})$/m }
+
   end
 end
 
-testapphost = File.read('README.md').match(/\s*testapp_IP = ((?:[0-9]{1,3}\.){3}[0-9]{1,3})$/m)[1]
-testappport = File.read('README.md').match(/\s*testapp_port = ([0-9]{1,5})$/m)[1]
+testapphost = File.read('README.md').match(/\s*testapp_IP\s*=\s*((?:[0-9]{1,3}\.){3}[0-9]{1,3})$/m)[1]
+testappport = File.read('README.md').match(/\s*testapp_port\s*=\s*([0-9]{1,5})$/m)[1]
 
 control 'Configuration' do
   title 'Check testapp installation scenarios'
@@ -62,8 +63,3 @@ control 'Reddit-APP' do
       its('body') { should match match(%r{href\='https:\/\/travis-ci\.org\/'}) }
   end
 end
-
-
-
-
-


### PR DESCRIPTION
добавил в regex правило, что бы народ смог писать в своих README.md значение переменных testapp_IP и testapp_port как с пробелами так и без них
